### PR TITLE
Fix MPI warning in GalaxSee example

### DIFF
--- a/BCCD_Examples/GalaxSee/Gal.cpp
+++ b/BCCD_Examples/GalaxSee/Gal.cpp
@@ -58,6 +58,12 @@ int main(int argc, char** argv) {
 	startTimer();
 #endif
 
+    char I_MPI_FABRICS[]="I_MPI_FABRICS=shm:ofi";
+    char FI_PROVIDER[]="FI_PROVIDER=tcp";
+    char SLURM_MPI_TYPE[]="SLURM_MPI_TYPE=pmi2";
+    putenv(I_MPI_FABRICS);
+    putenv(FI_PROVIDER);
+    putenv(SLURM_MPI_TYPE);
     setup_mpi(&argc,&argv,&g_mpi);
     
 


### PR DESCRIPTION
Due to missing environment variables, running the simulation would throw a warning. I followed the instructions on [this](https://oblivion-docs.readthedocs.io/en/latest/scripts.html) page to add the appropriate environment variables before setting up MPI in the `Gal.cpp` file.